### PR TITLE
INBOX-399 Enonic Market not available from servers that relies on a proxy

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/market/MarketConfig.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/market/MarketConfig.java
@@ -3,4 +3,5 @@ package com.enonic.xp.admin.impl.market;
 public @interface MarketConfig
 {
     String marketUrl() default "https://market.enonic.com/applications";
+    String marketProxy() default "";
 }

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/market/MarketDataProvider.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/market/MarketDataProvider.java
@@ -4,5 +4,5 @@ import com.squareup.okhttp.Response;
 
 public interface MarketDataProvider
 {
-    Response fetch( String url, String version, int start, int count );
+    Response fetch( String url, String proxy, String version, int start, int count );
 }

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/market/MarketDataProviderImpl.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/market/MarketDataProviderImpl.java
@@ -11,6 +11,10 @@ import com.squareup.okhttp.Response;
 
 import com.enonic.xp.market.MarketException;
 
+import com.squareup.okhttp.HttpUrl;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
 @Component(immediate = true)
 public class MarketDataProviderImpl
     implements MarketDataProvider
@@ -19,11 +23,19 @@ public class MarketDataProviderImpl
 
     private static final int readTimeout = 10_000;
 
-    public Response fetch( final String url, final String version, final int start, final int count )
+    public Response fetch( final String url, final String proxyUrl, final String version, final int start, final int count )
     {
         final Request request = MarketRequestFactory.create( url, version, start, count );
 
+
         final OkHttpClient client = new OkHttpClient();
+
+        HttpUrl parsedProxyUrl = HttpUrl.parse(proxyUrl);
+        if (parsedProxyUrl !=null && parsedProxyUrl.host()!=null && !"".equals(parsedProxyUrl.host()) && parsedProxyUrl.scheme()!=null){
+            Proxy proxy = new Proxy(Proxy.Type.valueOf(parsedProxyUrl.scheme().toUpperCase()), new InetSocketAddress(parsedProxyUrl.host(), parsedProxyUrl.port()));
+            client.setProxy(proxy);
+        }
+
         client.setReadTimeout( readTimeout, TimeUnit.MILLISECONDS );
         client.setConnectTimeout( connectionTimeout, TimeUnit.MILLISECONDS );
 

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/market/MarketServiceImpl.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/market/MarketServiceImpl.java
@@ -24,6 +24,7 @@ public class MarketServiceImpl
     implements MarketService
 {
     private String marketUrl;
+    private String marketProxy;
 
     private MarketDataProvider provider;
 
@@ -31,12 +32,13 @@ public class MarketServiceImpl
     public void activate( final MarketConfig config )
     {
         this.marketUrl = config.marketUrl();
+        this.marketProxy = config.marketProxy();
     }
 
     @Override
     public MarketApplicationsJson get( final String version, final int from, final int count )
     {
-        final Response response = this.provider.fetch( this.marketUrl, version, from, count );
+        final Response response = this.provider.fetch( this.marketUrl, this.marketProxy, version, from, count );
 
         return parseResponse( response );
     }

--- a/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/market/MarketServiceImplTest.java
+++ b/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/market/MarketServiceImplTest.java
@@ -23,6 +23,7 @@ public class MarketServiceImplTest
     private MarketServiceImpl marketService;
 
     private String marketUrl = "https://market.enonic.com/applications";
+    private String marketProxy = "";
 
     @Before
     public void setUp()
@@ -66,7 +67,7 @@ public class MarketServiceImplTest
         final String version = "6.3.0";
         final Response response = createResponse( code );
 
-        Mockito.when( provider.fetch( this.marketUrl, version, 0, 10 ) ).
+        Mockito.when( provider.fetch( this.marketUrl, this.marketProxy, version, 0, 10 ) ).
             thenReturn( response );
 
         try


### PR DESCRIPTION
I created an example implementation that I have successfully tested with Enonic XP Market behind a proxy. This way of doing it requires a double config, one in a new config file com.enonic.xp.app.cfg and the same config in com.enonic.xp.market.cfg, so it should be worked on a better designed solution (I just need something that works for now)

**Added property** in com.enonic.xp.market.cfg
(This is used when contacting enonic market to list applications)
marketProxy = http://localhost:5865

Note: **New config file** xp_home/config/com.enonic.xp.app.cfg
(This is used in ApplicationServiceImpl.java when installing an application)
marketProxy = http://localhost:5865
